### PR TITLE
Add quest framework

### DIFF
--- a/Assets/Scripts/Core/Item/Item.cs
+++ b/Assets/Scripts/Core/Item/Item.cs
@@ -42,6 +42,8 @@ public sealed class Item : MonoBehaviour
         if (inv == null) return;
 
         int stored = inv.TryAddItem(data, amount);
+        if(stored > 0)
+            QuestEventBus.OnItemCollected?.Invoke(data.itemName, stored);
         amount -= stored;
         if (amount <= 0) Destroy(gameObject);
     }

--- a/Assets/Scripts/Core/Managers/GameManager.cs
+++ b/Assets/Scripts/Core/Managers/GameManager.cs
@@ -25,6 +25,7 @@ public sealed class GameManager : MonoBehaviour
     public AudioManager AudioManager { get; private set; }
     public ItemManager ItemManager { get; private set; }   // ← NEW
     public SkillManager SkillManager { get; private set; }   // add near the other managers
+    public QuestManager QuestManager { get; private set; }
 
     public WorldTilemapViewer WorldTilemapViewer { get; private set; }
 
@@ -51,6 +52,7 @@ public sealed class GameManager : MonoBehaviour
         UnitManager = gameObject.AddComponent<UnitManager>();
         WorldTilemapViewer = gameObject.AddComponent<WorldTilemapViewer>();
         ItemManager = gameObject.AddComponent<ItemManager>();  // ← NEW
+        QuestManager = gameObject.AddComponent<QuestManager>();
         /* player and camera (lazy-initialised) */
         PlayerManager = gameObject.AddComponent<PlayerManager>();
         SkillManager = gameObject.AddComponent<SkillManager>();
@@ -89,7 +91,8 @@ public sealed class GameManager : MonoBehaviour
             PlayerManager.Initialize();
             UnitManager.Initialize();
             ItemManager.Initialize();
-            
+            QuestManager.Initialize();
+
             AudioManager.Initialize(gameData.levelUpClip);   // ← NEW
             //MusicManager.Initialize(gameData.soundFont);
         }
@@ -106,5 +109,7 @@ public sealed class GameManager : MonoBehaviour
     void OnWorldFinished()
     {
         UIManager.DisplayWorldMap(WorldManager.GetCurrentWorld());
+        if(QuestManager != null)
+            QuestManager.Initialize();
     }
 }

--- a/Assets/Scripts/Core/Player/TerrainEditService.cs
+++ b/Assets/Scripts/Core/Player/TerrainEditService.cs
@@ -352,6 +352,9 @@ void RemoveWholeTree(int rootX, int rootY, int treeId, int airId)
     /* ───────────── FX / drops / XP ───────────── */
     void PostEffects(int wx,int wy,int oldId,int newId,TileData oldData)
     {
+        if(oldId > 0 && oldId != newId)
+            QuestEventBus.OnTileMined?.Invoke(oldId);
+
         if (oldData?.dropItem != null)
         {
             if (ItemManager.Instance == null) ItemManager.Initialize();

--- a/Assets/Scripts/Core/Quests/quests
+++ b/Assets/Scripts/Core/Quests/quests
@@ -53,6 +53,21 @@ public class ReachChunkFlagObjectiveDef : ObjectiveDef
     public override ObjectiveTracker CreateTracker() => new ReachChunkFlagTracker(this);
 }
 
+[CreateAssetMenu(menuName = "Game/Quests/Objective/Mine Tile")]
+public class MineTileObjectiveDef : ObjectiveDef
+{
+    public TileData tile;
+    public int      amount = 1;
+    public override ObjectiveTracker CreateTracker() => new MineTileTracker(this);
+}
+
+[CreateAssetMenu(menuName = "Game/Quests/Objective/Talk To NPC")]
+public class TalkToNpcObjectiveDef : ObjectiveDef
+{
+    public string npcID;
+    public override ObjectiveTracker CreateTracker() => new TalkToNpcTracker(this);
+}
+
 // ───────────────────────────────────  QUEST DEF  ──────────────────────────────────────
 [Serializable]
 public class QuestStep
@@ -60,6 +75,13 @@ public class QuestStep
     [TextArea] public string narrative;
     public ObjectiveLogic   logic   = ObjectiveLogic.All;
     public ObjectiveDef[]   objectives;
+}
+
+[Serializable]
+public struct SkillRequirement
+{
+    public SkillId skill;
+    public int     level;
 }
 
 [CreateAssetMenu(menuName = "Game/Quest")]
@@ -70,6 +92,10 @@ public class QuestDef : ScriptableObject
     public string displayName;
     [TextArea] public string description;
     public bool   repeatable;
+
+    [Header("Requirements")]
+    public SkillRequirement[] skillRequirements;
+    public string[]           prerequisiteQuestIDs;
 
     [Header("Flow")]
     public QuestStep[] steps;
@@ -83,6 +109,7 @@ public static class QuestEventBus
 {
     public static Action<string,int> OnItemCollected;            // (itemID, amount)
     public static Action<string>     OnEnemyKilled;              // enemyID
+    public static Action<int>        OnTileMined;                // tileID
     public static Action<ChunkFlags> OnChunkEntered;
     public static Action<string>     OnNPCDialogueFinished;      // npcID
     public static Action<string,object> OnCustom;                // (eventKey, payload)
@@ -134,6 +161,24 @@ public sealed class ReachChunkFlagTracker : ObjectiveTracker
     public override void Activate(){ base.Activate(); QuestEventBus.OnChunkEntered += Check; }
     public override void Deactivate(){ QuestEventBus.OnChunkEntered -= Check; base.Deactivate(); }
     void Check(ChunkFlags f){ if(f.HasFlag(def.targetFlag)) Add(); }
+}
+
+public sealed class MineTileTracker : ObjectiveTracker
+{
+    readonly MineTileObjectiveDef def;
+    public MineTileTracker(MineTileObjectiveDef d){ def=d; Target=d.amount; }
+    public override void Activate(){ base.Activate(); QuestEventBus.OnTileMined += Check; }
+    public override void Deactivate(){ QuestEventBus.OnTileMined -= Check; base.Deactivate(); }
+    void Check(int id){ if(def.tile==null || id==def.tile.tileID) Add(); }
+}
+
+public sealed class TalkToNpcTracker : ObjectiveTracker
+{
+    readonly TalkToNpcObjectiveDef def;
+    public TalkToNpcTracker(TalkToNpcObjectiveDef d){ def=d; Target=1; }
+    public override void Activate(){ base.Activate(); QuestEventBus.OnNPCDialogueFinished += Check; }
+    public override void Deactivate(){ QuestEventBus.OnNPCDialogueFinished -= Check; base.Deactivate(); }
+    void Check(string id){ if(id==def.npcID) Add(); }
 }
 
 // ───────────────────────────────────  QUEST (runtime)  ────────────────────────────────
@@ -236,9 +281,20 @@ public sealed class QuestManager : MonoBehaviour
             if (MayStart(def)) StartQuest(def);
     }
 
-    bool MayStart(QuestDef d)=>
-        (!completed.Contains(d.questID) || d.repeatable) &&
-         !active.Exists(q=>q.Def==d);
+    bool MayStart(QuestDef d)
+    {
+        if(active.Exists(q=>q.Def==d)) return false;
+        if(completed.Contains(d.questID) && !d.repeatable) return false;
+
+        foreach(var req in d.skillRequirements)
+            if(GameManager.Instance.SkillManager.GetLevel(req.skill) < req.level)
+                return false;
+
+        foreach(var id in d.prerequisiteQuestIDs)
+            if(!completed.Contains(id)) return false;
+
+        return true;
+    }
 
     public void StartQuest(QuestDef def)
     {

--- a/Assets/Scripts/Core/Unit/Entity.cs
+++ b/Assets/Scripts/Core/Unit/Entity.cs
@@ -18,6 +18,11 @@ public abstract class Entity : MonoBehaviour
     {
         if (Dead || dmg <= 0) return;
         HP = Mathf.Max(HP - dmg, 0);
-        if (Dead) Destroy(gameObject);
+        if (Dead)
+        {
+            if(this is Unit u && !(u is PlayerUnit))
+                QuestEventBus.OnEnemyKilled?.Invoke(u.template ? u.template.displayName : u.name);
+            Destroy(gameObject);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement one-file quest system under `Assets/Scripts/Core/Quests/quests`
- broadcast quest progress via `QuestEventBus`
- integrate quest manager in `GameManager`
- fire quest events when collecting items, mining tiles and killing enemies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cfbf65d8c8321a71cdf04dfe1bcc2