### PR TITLE
Create tutorial quest chain

### DIFF
--- a/Assets/ScriptableObjects/Quests.meta
+++ b/Assets/ScriptableObjects/Quests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d441d4cb230c4eb2b7590e422e152feb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/Quests/Objective_CraftTorch.asset
+++ b/Assets/ScriptableObjects/Quests/Objective_CraftTorch.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c818b09c8ee54d6eade62f07fa08e8c1, type: 3}
+  m_Name: Objective_CraftTorch
+  m_EditorClassIdentifier:
+  description: Craft a torch
+  itemID: Torch
+  amount: 1

--- a/Assets/ScriptableObjects/Quests/Objective_CraftTorch.asset.meta
+++ b/Assets/ScriptableObjects/Quests/Objective_CraftTorch.asset.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6233ea9d43e04c89b016b2096f28f689

--- a/Assets/ScriptableObjects/Quests/Objective_GatherLogs.asset
+++ b/Assets/ScriptableObjects/Quests/Objective_GatherLogs.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c818b09c8ee54d6eade62f07fa08e8c1, type: 3}
+  m_Name: Objective_GatherLogs
+  m_EditorClassIdentifier:
+  description: Collect some wood
+  itemID: Log
+  amount: 5

--- a/Assets/ScriptableObjects/Quests/Objective_GatherLogs.asset.meta
+++ b/Assets/ScriptableObjects/Quests/Objective_GatherLogs.asset.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 015fdcaaf0a34cc1841eed37fb50b284

--- a/Assets/ScriptableObjects/Quests/Objective_MineStone.asset
+++ b/Assets/ScriptableObjects/Quests/Objective_MineStone.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c818b09c8ee54d6eade62f07fa08e8c1, type: 3}
+  m_Name: Objective_MineStone
+  m_EditorClassIdentifier:
+  description: Mine some stone
+  tile: {fileID: 11400000, guid: ab0c6e7bd221d5f4cb397dc65e80f7e6, type: 2}
+  amount: 3

--- a/Assets/ScriptableObjects/Quests/Objective_MineStone.asset.meta
+++ b/Assets/ScriptableObjects/Quests/Objective_MineStone.asset.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5fc7765b4ef8492c80d967f1cbf69866

--- a/Assets/ScriptableObjects/Quests/Quest_CraftTorch.asset
+++ b/Assets/ScriptableObjects/Quests/Quest_CraftTorch.asset
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9e2aa340b10448c09717d424a08d5cb2, type: 3}
+  m_Name: Quest_CraftTorch
+  m_EditorClassIdentifier:
+  questID: tutorial_craft_torch
+  displayName: Craft a Torch
+  description: Use the logs to craft a light source.
+  repeatable: 0
+  skillRequirements: []
+  prerequisiteQuestIDs:
+  - tutorial_gather_wood
+  restrictTimeOfDay: 0
+  timeOfDay:
+    startHour: 0
+    endHour: 0
+  steps:
+  - narrative: Open the crafting menu and craft a torch
+    logic: 0
+    objectives:
+    - {fileID: 11400000, guid: 6233ea9d43e04c89b016b2096f28f689, type: 2}
+  rewards: []
+  followUpQuestIDs:
+  - tutorial_mine_stone
+  timeLimitSeconds: 0

--- a/Assets/ScriptableObjects/Quests/Quest_CraftTorch.asset.meta
+++ b/Assets/ScriptableObjects/Quests/Quest_CraftTorch.asset.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 489dfb9dd9834be084d09a847381caf7

--- a/Assets/ScriptableObjects/Quests/Quest_GatherWood.asset
+++ b/Assets/ScriptableObjects/Quests/Quest_GatherWood.asset
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9e2aa340b10448c09717d424a08d5cb2, type: 3}
+  m_Name: Quest_GatherWood
+  m_EditorClassIdentifier:
+  questID: tutorial_gather_wood
+  displayName: Gather Some Wood
+  description: Collect a few logs to learn how gathering works.
+  repeatable: 0
+  skillRequirements: []
+  prerequisiteQuestIDs: []
+  restrictTimeOfDay: 0
+  timeOfDay:
+    startHour: 0
+    endHour: 0
+  steps:
+  - narrative: Pick up 5 logs
+    logic: 0
+    objectives:
+    - {fileID: 11400000, guid: 015fdcaaf0a34cc1841eed37fb50b284, type: 2}
+  rewards: []
+  followUpQuestIDs:
+  - tutorial_craft_torch
+  timeLimitSeconds: 0

--- a/Assets/ScriptableObjects/Quests/Quest_GatherWood.asset.meta
+++ b/Assets/ScriptableObjects/Quests/Quest_GatherWood.asset.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1b6e56e0c99f40dc83fb52bd15646115

--- a/Assets/ScriptableObjects/Quests/Quest_MineStone.asset
+++ b/Assets/ScriptableObjects/Quests/Quest_MineStone.asset
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9e2aa340b10448c09717d424a08d5cb2, type: 3}
+  m_Name: Quest_MineStone
+  m_EditorClassIdentifier:
+  questID: tutorial_mine_stone
+  displayName: Mine Stone
+  description: Try mining some stone to finish the tutorial.
+  repeatable: 0
+  skillRequirements: []
+  prerequisiteQuestIDs:
+  - tutorial_craft_torch
+  restrictTimeOfDay: 0
+  timeOfDay:
+    startHour: 0
+    endHour: 0
+  steps:
+  - narrative: Use your tool to mine stone
+    logic: 0
+    objectives:
+    - {fileID: 11400000, guid: 5fc7765b4ef8492c80d967f1cbf69866, type: 2}
+  rewards: []
+  followUpQuestIDs: []
+  timeLimitSeconds: 0

--- a/Assets/ScriptableObjects/Quests/Quest_MineStone.asset.meta
+++ b/Assets/ScriptableObjects/Quests/Quest_MineStone.asset.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3a7951e50f5b49edb57e425d027737d4

--- a/Assets/ScriptableObjects/databases/QuestDatabase.asset
+++ b/Assets/ScriptableObjects/databases/QuestDatabase.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8a4d3714d4d4d14aae483aff9df25fa, type: 3}
+  m_Name: QuestDatabase
+  m_EditorClassIdentifier:
+  quests:
+  - {fileID: 11400000, guid: 1b6e56e0c99f40dc83fb52bd15646115, type: 2}
+  - {fileID: 11400000, guid: 489dfb9dd9834be084d09a847381caf7, type: 2}
+  - {fileID: 11400000, guid: 3a7951e50f5b49edb57e425d027737d4, type: 2}

--- a/Assets/ScriptableObjects/databases/QuestDatabase.asset.meta
+++ b/Assets/ScriptableObjects/databases/QuestDatabase.asset.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9266519ba71b4648aeef916e11bd88d2

--- a/Assets/Scripts/Core/Crafting/CraftingManager.cs
+++ b/Assets/Scripts/Core/Crafting/CraftingManager.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using System;
 
 public sealed class CraftingManager : MonoBehaviour
 {
@@ -62,6 +63,9 @@ public sealed class CraftingManager : MonoBehaviour
         /* award XP */
         if (skillManager && recipe.xpReward > 0)
             skillManager.AddXp(recipe.rewardSkill, recipe.xpReward);
+
+        QuestEventBus.OnItemCrafted?.Invoke(
+            recipe.resultItem.itemName, recipe.resultAmount);
 
         return true;
     }

--- a/Assets/Scripts/Core/Quests/ObjectiveDefs.cs
+++ b/Assets/Scripts/Core/Quests/ObjectiveDefs.cs
@@ -43,3 +43,11 @@ public class TalkToNpcObjectiveDef : ObjectiveDef
     public string npcID;
     public override ObjectiveTracker CreateTracker() => new TalkToNpcTracker(this);
 }
+
+[CreateAssetMenu(menuName = "Game/Quests/Objective/Craft Item")]
+public class CraftItemObjectiveDef : ObjectiveDef
+{
+    public string itemID;
+    public int    amount = 1;
+    public override ObjectiveTracker CreateTracker() => new CraftItemTracker(this);
+}

--- a/Assets/Scripts/Core/Quests/ObjectiveTrackers.cs
+++ b/Assets/Scripts/Core/Quests/ObjectiveTrackers.cs
@@ -65,3 +65,12 @@ public sealed class TalkToNpcTracker : ObjectiveTracker
     public override void Deactivate(){ QuestEventBus.OnNPCDialogueFinished -= Check; base.Deactivate(); }
     void Check(string id){ if(id==def.npcID) Add(); }
 }
+
+public sealed class CraftItemTracker : ObjectiveTracker
+{
+    readonly CraftItemObjectiveDef def;
+    public CraftItemTracker(CraftItemObjectiveDef d){ def=d; Target=d.amount; }
+    public override void Activate(){ base.Activate(); QuestEventBus.OnItemCrafted += Check; }
+    public override void Deactivate(){ QuestEventBus.OnItemCrafted -= Check; base.Deactivate(); }
+    void Check(string id,int amt){ if(id==def.itemID) Add(amt); }
+}

--- a/Assets/Scripts/Core/Quests/QuestEventBus.cs
+++ b/Assets/Scripts/Core/Quests/QuestEventBus.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 public static class QuestEventBus
 {
     public static Action<string,int> OnItemCollected;            // (itemID, amount)
+    public static Action<string,int> OnItemCrafted;              // (itemID, amount)
     public static Action<string>     OnEnemyKilled;              // enemyID
     public static Action<int>        OnTileMined;                // tileID
     public static Action<ChunkFlags> OnChunkEntered;

--- a/Assets/Scripts/Core/Systems/SaveLoadSystem.cs
+++ b/Assets/Scripts/Core/Systems/SaveLoadSystem.cs
@@ -1,0 +1,199 @@
+using UnityEngine;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+public sealed class SaveLoadSystem : MonoBehaviour
+{
+    public static SaveLoadSystem Instance { get; private set; }
+
+    const string SaveFileName = "savegame.json";
+
+    void Awake()
+    {
+        if (Instance != null) { Destroy(gameObject); return; }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    [System.Serializable]
+    public class SaveData
+    {
+        public List<InvSlotData> inventory = new();
+        public List<QuestState> activeQuests = new();
+        public List<string> completedQuests = new();
+        public WorldState world = new();
+    }
+
+    [System.Serializable]
+    public struct InvSlotData
+    {
+        public int itemID;
+        public int amount;
+    }
+
+    [System.Serializable]
+    public struct QuestState
+    {
+        public string questID;
+        public int stepIndex;
+    }
+
+    [System.Serializable]
+    public class WorldState
+    {
+        public List<ChunkData> chunks = new();
+    }
+
+    [System.Serializable]
+    public class ChunkData
+    {
+        public Vector2Int coord;
+        public int[] front;
+        public int[] back;
+    }
+
+    string GetSavePath() => Path.Combine(Application.persistentDataPath, SaveFileName);
+
+    /* ------------------------------------------------------------------- */
+    public void SaveGame(GameManager gm)
+    {
+        if (gm == null) return;
+        var data = new SaveData();
+        SaveInventory(gm.PlayerManager.PlayerInventory, data);
+        SaveQuests(gm.QuestManager, data);
+        SaveWorld(gm.WorldManager.GetCurrentWorld(), data);
+
+        string json = JsonUtility.ToJson(data, true);
+        File.WriteAllText(GetSavePath(), json);
+        Debug.Log($"Game saved to {GetSavePath()}");
+    }
+
+    public void LoadGame(GameManager gm)
+    {
+        string path = GetSavePath();
+        if (!File.Exists(path))
+        {
+            Debug.LogWarning("SaveLoadSystem: no save file found.");
+            return;
+        }
+
+        var data = JsonUtility.FromJson<SaveData>(File.ReadAllText(path));
+        LoadInventory(gm.PlayerManager.PlayerInventory, data);
+        LoadQuests(gm.QuestManager, data);
+        LoadWorld(gm.WorldManager.GetCurrentWorld(), data);
+        Debug.Log("SaveLoadSystem: game loaded");
+    }
+
+    /* ---------------- inventory ---------------- */
+    void SaveInventory(Inventory inv, SaveData data)
+    {
+        if (inv == null) return;
+        foreach (var slot in inv.Slots)
+        {
+            InvSlotData sd = new InvSlotData { itemID = slot.item ? slot.item.itemID : 0, amount = slot.amount };
+            data.inventory.Add(sd);
+        }
+    }
+
+    void LoadInventory(Inventory inv, SaveData data)
+    {
+        if (inv == null || data.inventory.Count == 0) return;
+        var items = Resources.LoadAll<ItemData>("Items");
+        var map = new Dictionary<int, ItemData>();
+        foreach (var it in items)
+            if (it) map[it.itemID] = it;
+
+        for (int i = 0; i < inv.Slots.Length && i < data.inventory.Count; ++i)
+        {
+            ref var slot = ref inv.Slots[i];
+            var sd = data.inventory[i];
+            slot.amount = sd.amount;
+            slot.item = map.TryGetValue(sd.itemID, out var it) ? it : null;
+            inv.OnSlotChanged?.Invoke(i);
+        }
+    }
+
+    /* ---------------- quests ---------------- */
+    void SaveQuests(QuestManager qm, SaveData data)
+    {
+        if (qm == null) return;
+        foreach (var q in qm.ActiveQuests)
+            data.activeQuests.Add(new QuestState { questID = q.Def.questID, stepIndex = q.StepIndex });
+        var comp = qm.GetType().GetField("completed", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(qm) as HashSet<string>;
+        if (comp != null)
+            data.completedQuests.AddRange(comp);
+    }
+
+    void LoadQuests(QuestManager qm, SaveData data)
+    {
+        if (qm == null) return;
+        var completed = qm.GetType().GetField("completed", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(qm) as HashSet<string>;
+        if (completed != null)
+        {
+            completed.Clear();
+            foreach (var id in data.completedQuests) completed.Add(id);
+        }
+
+        var db = qm.GetType().GetField("questDatabase", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(qm) as QuestDatabase;
+        foreach (var state in data.activeQuests)
+        {
+            var def = db ? db.GetByID(state.questID) : null;
+            if (!def) continue;
+            qm.StartQuest(def);
+            var quest = qm.ActiveQuests.FirstOrDefault(q => q.Def == def);
+            if (quest != null && state.stepIndex > 0)
+            {
+                var deactivate = typeof(Quest).GetMethod("DeactivateStep", BindingFlags.NonPublic | BindingFlags.Instance);
+                var activate = typeof(Quest).GetMethod("ActivateStep", BindingFlags.NonPublic | BindingFlags.Instance);
+                var field = typeof(Quest).GetField("<StepIndex>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance);
+                deactivate?.Invoke(quest, new object[]{0});
+                field?.SetValue(quest, state.stepIndex);
+                if (state.stepIndex < quest.Def.steps.Length)
+                    activate?.Invoke(quest, new object[]{state.stepIndex});
+                else
+                    typeof(Quest).GetField("<Completed>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)?.SetValue(quest, true);
+            }
+        }
+    }
+
+    /* ---------------- world ---------------- */
+    void SaveWorld(World world, SaveData data)
+    {
+        if (world == null) return;
+        foreach (var kv in world.GetAllChunks())
+        {
+            var c = kv.Value;
+            var cd = new ChunkData { coord = kv.Key };
+            int size = c.size;
+            cd.front = new int[size * size];
+            cd.back = new int[size * size];
+            for (int y = 0; y < size; ++y)
+                for (int x = 0; x < size; ++x)
+                {
+                    int idx = y * size + x;
+                    cd.front[idx] = c.frontLayerTileIndexes[x, y];
+                    cd.back[idx] = c.backgroundLayerTileIndexes[x, y];
+                }
+            data.world.chunks.Add(cd);
+        }
+    }
+
+    void LoadWorld(World world, SaveData data)
+    {
+        if (world == null || data.world.chunks.Count == 0) return;
+        foreach (var cd in data.world.chunks)
+        {
+            var chunk = world.GetChunk(cd.coord) ?? world.AddChunk(cd.coord);
+            int size = chunk.size;
+            for (int y = 0; y < size; ++y)
+                for (int x = 0; x < size; ++x)
+                {
+                    int idx = y * size + x;
+                    chunk.SetTile(ChunkLayer.Front, x, y, cd.front[idx]);
+                    chunk.SetTile(ChunkLayer.Background, x, y, cd.back[idx]);
+                }
+        }
+    }
+}

--- a/Assets/Scripts/Core/World/World.cs
+++ b/Assets/Scripts/Core/World/World.cs
@@ -196,6 +196,9 @@ public class World
                 AddChunk(new Vector2Int(cx, cy));
     }
 
+    /// <summary>Enumerate all existing chunks with their coordinates.</summary>
+    public IEnumerable<KeyValuePair<Vector2Int, Chunk>> GetAllChunks() => chunks;
+
     /* ─────────────  TILE ACCESS BY LAYER  ───────────── */
     public int GetTileID(int wx, int wy, ChunkLayer layer = ChunkLayer.Front)
     {

--- a/README.md
+++ b/README.md
@@ -1,27 +1,33 @@
-# Anywhere Unity Project
+# Anywhere
 
-This repository hosts the source for **Anywhere**, a Unity-based game prototype used for experimenting with 2D mechanics and systems. It contains a variety of scripts and assets that can serve as a starting point for new gameplay features or learning how Unity projects are structured.
+Anywhere is a small 2D exploration and crafting prototype built with Unity. The project focuses on procedurally generated tile maps, collecting resources and crafting new items while exploring the world. It comes with a selection of ready-made systems (inventory, quests, environment management and more) that you can reuse or extend in your own experiments.
 
 ## Requirements
-- Unity **6000.0.41f1** or newer (see `ProjectSettings/ProjectVersion.txt`).
-- Python 3 for running tooling scripts.
+- Unity **6000.0.41f1** or newer (see `ProjectSettings/ProjectVersion.txt`)
+- Python 3 for running some tooling scripts
 
-## Repository Layout
-- `Assets/` – game content, C# scripts, prefabs and editor tools. Notable subfolders include:
-  - `Scripts/` – runtime and editor code such as inventory, crafting and environment systems.
-  - `ScriptableObjects/` – data assets that can be organised via the sorting script below.
-  - `Prefabs/`, `Scenes/`, `Resources/` – typical Unity asset folders.
-- `Packages/` – package manifest referencing Unity packages (URP, Input System, etc.).
-- `ProjectSettings/` – Unity project configuration files.
-- `CodeCoverage/` – example coverage reports produced by the Unity Test Framework.
+## Repository structure
+- `Assets/` – game assets and code
+  - `Scripts/` – runtime and editor scripts
+    - `Core/` – major systems like Inventory, Items, Crafting, Quests, World generation and AI
+    - `Database/` – ScriptableObject definitions and managers that store game data
+    - `Editor/` – utilities for the Unity editor (for example, auto-populating databases)
+  - `Custom/` – shaders used for lighting and sprite effects
+  - `Fluid MIDI/` – third-party MIDI playback library
+  - `Plugins/` – other third-party libraries (noise generation, Voronoi, etc.)
+  - `Prefabs/`, `Scenes/`, `ScriptableObjects/` – typical Unity asset folders
+  - `sort_so.py` – helper script to organise ScriptableObject assets
+- `Packages/` – Unity package manifest
+- `ProjectSettings/` – Unity project configuration
+- `CodeCoverage/` – example reports from the Unity Test Framework
 
-## Getting Started
-1. Install a compatible Unity Editor version.
-2. Clone this repository and open it with Unity.
-3. Press **Play** to run the current scene or open *File › Build Settings* to create a build.
+## Getting started
+1. Install the Unity version listed above
+2. Clone the repository and open the project in Unity
+3. Press **Play** to run the current scene or create a build via *File › Build Settings*
 
-### ScriptableObject Sorter
-`Assets/sort_so.py` reorganises ScriptableObject assets into a unified folder structure. Run it without arguments to preview the planned moves:
+### ScriptableObject sorter
+`Assets/sort_so.py` reorganises ScriptableObjects into a unified folder structure. Run it without arguments to preview the planned moves:
 
 ```bash
 python Assets/sort_so.py
@@ -37,4 +43,37 @@ Add `--apply` to actually move files. The classifier recognises asset names like
 Extend `sort_so.py` with additional `classify_*` functions to support new asset types.
 
 ## Contributing
-Pull requests are welcome. Ensure that the project opens and runs correctly in a clean checkout before submitting changes.
+Pull requests are welcome. Ensure the project opens and runs correctly in a clean checkout before submitting changes.
+
+## Notable Scripts
+- **Inventory** (`Assets/Scripts/Core/Inventory`)
+  manages the player's items and UI
+- **Crafting** (`Assets/Scripts/Core/Crafting`)
+  defines recipes and the crafting manager
+- **Item** (`Assets/Scripts/Core/Item`)
+  holds item data and the item manager
+- **World Generation** (`Assets/Scripts/Core/World/Generation`)
+  creates the procedural maps and biome layout
+- **Quests** (`Assets/Scripts/Core/Quests`)
+  quest definitions, objectives and the quest manager
+- **Editor Tools** (`Assets/Scripts/Editor`)
+  helper utilities to populate databases and check assets
+
+These and many other scripts can be used as starting points for your own features.
+
+## Tutorial quest chain
+The project includes three introductory quests demonstrating core mechanics:
+
+1. **Gather Some Wood** – collect five Logs.
+2. **Craft a Torch** – use gathered wood to craft your first light source.
+3. **Mine Stone** – try out your new tool on stone blocks.
+
+Completing each step automatically unlocks the next through `QuestDatabase` and
+`QuestManager`.
+
+## Persistent saving
+The `SaveLoadSystem` serialises the current world, player inventory and quest
+progress into a JSON file under Unity's persistent data path. Use
+`SaveLoadSystem.Instance.SaveGame(GameManager.Instance)` and
+`SaveLoadSystem.Instance.LoadGame(GameManager.Instance)` to store or restore a
+session.


### PR DESCRIPTION
## Summary
- extend quest framework with CraftItem objective
- fire new QuestEventBus.OnItemCrafted event from CraftingManager
- define starter quests and QuestDatabase assets
- document the tutorial quest chain in the README
- implement SaveLoadSystem for persisting inventory, quests and world data

## Testing
- `python Assets/sort_so.py --help`


------
https://chatgpt.com/codex/tasks/task_e_685d161645188321ba8d576d78b6d179