### PR TITLE
Add skill progress and XP removal

### DIFF
--- a/Assets/Scripts/Core/Skills/SkillManager.cs
+++ b/Assets/Scripts/Core/Skills/SkillManager.cs
@@ -13,7 +13,9 @@ public sealed class SkillManager : MonoBehaviour
 {
     /* ───────── events ───────── */
     public event Action<SkillId, int> OnXpGained;
+    public event Action<SkillId, int> OnXpLost;
     public event Action<SkillId, int> OnLevelUp;
+    public event Action<SkillId, int> OnLevelDown;
 
     /* ───────── public API ───────── */
     public int  GetXp       (SkillId id) => data.Get(id);
@@ -29,6 +31,20 @@ public sealed class SkillManager : MonoBehaviour
 
         int next = def.GetXpForLevel(lv + 1);
         return next - GetXp(id);
+    }
+
+    public float GetProgress(SkillId id)
+    {
+        if (!TryGetDef(id, out var def)) return 0f;
+
+        int xp = GetXp(id);
+        int lvl = def.GetLevelForXp(xp);
+        if (lvl >= SkillDefinition.MaxLevel)
+            return 1f;
+
+        int cur = def.GetXpForLevel(lvl);
+        int next = def.GetXpForLevel(lvl + 1);
+        return Mathf.InverseLerp(cur, next, xp);
     }
 
     public int TotalXp
@@ -55,6 +71,25 @@ public sealed class SkillManager : MonoBehaviour
         int newLevel = def.GetLevelForXp(GetXp(id));
         if (newLevel > beforeLevel)
             OnLevelUp?.Invoke(id, newLevel);
+
+        return newLevel;
+    }
+
+    /// Remove XP. If the SkillId has no definition it is ignored.
+    public int RemoveXp(SkillId id, int delta)
+    {
+        if (delta <= 0 || !TryGetDef(id, out var def)) return GetLevel(id);
+
+        int beforeLevel = def.GetLevelForXp(GetXp(id));
+
+        data.Add(id, -delta);
+        data.Set(id, Mathf.Max(GetXp(id), 0));
+
+        OnXpLost?.Invoke(id, delta);
+
+        int newLevel = def.GetLevelForXp(GetXp(id));
+        if (newLevel < beforeLevel)
+            OnLevelDown?.Invoke(id, newLevel);
 
         return newLevel;
     }

--- a/Assets/Scripts/Core/UI/systems/SkillStatsUI.cs
+++ b/Assets/Scripts/Core/UI/systems/SkillStatsUI.cs
@@ -28,7 +28,9 @@ public sealed class SkillStatsUI : MonoBehaviour
         BuildUI();
 
         sm.OnXpGained += (_, __) => Redraw();
+        sm.OnXpLost   += (_, __) => Redraw();
         sm.OnLevelUp  += (_, __) => Redraw();
+        sm.OnLevelDown+= (_, __) => Redraw();
     }
 
     /* -------- prefab helpers ------- */
@@ -96,9 +98,10 @@ public sealed class SkillStatsUI : MonoBehaviour
             int xp    = sm.GetXp  (d.id);
             int next  = d.GetXpForLevel(Mathf.Min(lvl + 1, SkillDefinition.MaxLevel));
             int left  = next - xp;
+            float prog = sm.GetProgress(d.id);
 
             rows[d.id].text =
-                $"{d.id,-12} Lv {lvl,2}  {xp:N0} XP  ← {left:N0}";
+                $"{d.id,-12} Lv {lvl,2}  {xp:N0} XP  ← {left:N0}  ({prog:P0})";
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -78,3 +78,9 @@ progress into a JSON file under Unity's persistent data path. Use
 `SaveLoadSystem.Instance.LoadGame(GameManager.Instance)` to store or restore a
 session.
 
+## Skill system
+The `SkillManager` tracks experience for each skill and now supports XP removal
+via `RemoveXp`. It also exposes `GetProgress` to compute the player's progress
+towards the next level. UI elements such as `SkillStatsUI` use these helpers to
+display percentage progress.
+


### PR DESCRIPTION
## Summary
- extend `SkillManager` with XP removal and progress tracking
- update `SkillStatsUI` to show progress and respond to new events
- document the skill system in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2fe127808321b0a79a2911c81e83